### PR TITLE
fix: avoid null nodes when creating parent node path

### DIFF
--- a/src/projector.ts
+++ b/src/projector.ts
@@ -8,7 +8,7 @@ export interface AdvancedProjector extends Projector {
 
 let createParentNodePath = (node: Node, rootNode: Element) => {
   let parentNodePath: Node[] = [];
-  while (node !== rootNode) {
+  while (node && node !== rootNode) {
     parentNodePath.push(node);
     node = node.parentNode!;
   }


### PR DESCRIPTION
This also makes the code consistent w/ [maquette's default projector](https://github.com/AFASSoftware/maquette/blob/8c72fd5dd22dc301d923e28117adad0cc381c5c6/src/projector.ts#L25-L28)