### PR TITLE
fix: Handle camelCase styles and css variables

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,8 +5,13 @@ const DEFAULT_PROJECTION_OPTIONS: ProjectionOptions = {
   performanceLogger: () => undefined,
   eventHandlerInterceptor: undefined,
   styleApplyer: (domNode: HTMLElement, styleName: string, value: string) => {
-    // Provides a hook to add vendor prefixes for browsers that still need it.
-    (domNode.style as any)[styleName] = value;
+    if (styleName.charAt(0) === "-") {
+      // CSS variables must be set using setProperty
+      domNode.style.setProperty(styleName, value);
+    } else {
+      // properties like 'backgroundColor' must be set as a js-property
+      (domNode.style as any)[styleName] = value;
+    }
   },
 };
 


### PR DESCRIPTION
The bug with camel case style properties and CSS variables not working (https://github.com/AFASSoftware/maquette/issues/164) was fixed in the main repository, but not in the advanced projector.

This PR copies the fix from https://github.com/AFASSoftware/maquette/commit/2832257c0d2e46a6e0c34c8ba9f8aeb049f16708 into the advanced projector repository.