### PR TITLE
fix: projection leaking in createAdvancedProjector

### DIFF
--- a/src/projector.ts
+++ b/src/projector.ts
@@ -110,6 +110,7 @@ export let createAdvancedProjector = (
     projectorOptions.postProcessProjectionOptions?.(projectionOptions);
     let firstVNode = renderFunction();
     projection = domFunction(node, firstVNode, projectionOptions);
+    projectionOptions.eventHandlerInterceptor = undefined;
     projections.push(projection);
     renderFunctions.push(renderFunction);
     if (projectorOptions.afterFirstVNodeRendered) {


### PR DESCRIPTION
This PR fixes a memory leak of the last created `projection`.

`eventHandlerInterceptor` is created on the `projectionOptions` local variable from `createAdvancedProjector`. Until `addProjection` is called again, `projectionOptions` holds a reference to the previously created `eventHandlerInterceptor` which hold a reference to the previous `projection` and its DOM node.