### PR TITLE
Added rollup commands to make CJS and UMD releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maquette-advanced-projector",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maquette-advanced-projector",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
         "@types/chai-as-promised": "7.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "jsdom": "22.1.0",
         "jsdom-global": "3.0.2",
         "maquette": "3.6.0",
+        "rollup": "3.20.2",
         "sinon": "15.2.0",
         "sinon-chai": "3.7.0",
         "typescript-assistant": "^0.63.4"
@@ -5376,6 +5377,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.2.tgz",
+      "integrity": "sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rrweb-cssom": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maquette-advanced-projector",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A replacement for maquette's projector that is configurable",
   "module": "./dist/index.js",
   "main": "./dist/maquette-advanced-projector.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maquette-advanced-projector",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A replacement for maquette's projector that is configurable",
   "module": "./dist/index.js",
   "main": "./dist/maquette-advanced-projector.cjs.js",
@@ -15,7 +15,7 @@
     "fix": "tsa fix",
     "fixall": "tsa fixall",
     "clean": "tsa clean",
-    "dist": "tsc -p ./src/tsconfig.json",
+    "dist": "tsc -p ./src/tsconfig.json && rollup -c --bundleConfigAsCjs && uglifyjs ./dist/maquette-advanced-projector.umd.js -c unsafe=true,unsafe_comps=true,unsafe_math=true,passes=3 -m -o ./dist/maquette-advanced-projector.umd.min.js",
     "ci": "tsa ci",
     "coverage-show": "opn build/coverage/index.html",
     "fix:hooks": "husky install"
@@ -42,6 +42,7 @@
     "jsdom": "22.1.0",
     "jsdom-global": "3.0.2",
     "maquette": "3.6.0",
+    "rollup": "3.20.2",
     "sinon": "15.2.0",
     "sinon-chai": "3.7.0",
     "typescript-assistant": "^0.63.4"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,24 @@
+import pkg from './package.json';
+
+// Typescript creates the commonJS package, let rollup do the rest
+
+export default [
+  // browser-friendly UMD build
+  {
+    input: 'dist/index.js',
+    output: {
+      name: 'maquette',
+      file: pkg.browser,
+      format: 'umd'
+    },
+    plugins: []
+  },
+  // CommonJS build for nodeJS
+  {
+    input: 'dist/index.js',
+    output: {
+      file: pkg.main,
+      format: 'cjs'
+    }
+  },
+];


### PR DESCRIPTION
Hi! I was unable to use this package because of the missing UMD and CJS files on NPM (bug #13).

I fixed the problem by copying over Rollup commands and configuration from Maquette.